### PR TITLE
Podspec: Fix missing "swift" configuration + use package.json version as source

### DIFF
--- a/RNAirplay.podspec
+++ b/RNAirplay.podspec
@@ -9,8 +9,8 @@ Pod::Spec.new do |s|
   s.author         = package['author']
   s.homepage       = package['repository']['url']
   s.platform     = :ios, "7.0"
-  s.source       = { :git => "https://github.com/author/RNAirplay.git", :tag => "master" }
-  s.source_files  = "ios/**/*.{h,m}"
+  s.source       = { :git => "https://github.com/author/RNAirplay.git", :tag => package['version'] }
+  s.source_files  = "ios/**/*.{h,m,swift}"
   s.requires_arc = true
 
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-native-airplay-ios",
   "description": "AirPlay library for iOS",
   "summary": "Summary for PODS",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "author": {
     "name": "Andrey Efremov"
   },


### PR DESCRIPTION
Moving to v 1.0.9