### PR TITLE
fix: xcode 12 compatibility

### DIFF
--- a/RNAirplay.podspec
+++ b/RNAirplay.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
 
-  s.dependency "React"
+  s.dependency "React-Core"
   #s.dependency "others"
 
 end


### PR DESCRIPTION
Xcode 12 fails to build if a module depends on React instead of React-Core. Reference: https://github.com/facebook/react-native/issues/29633#issuecomment-694187116