### PR TITLE
Using Accent Color for AirPlayButton

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,8 @@ import { AirPlayButton } from "react-native-airplay-ios";
     normal: "",
     focused: "",
     highlighted: "",
-    selected: ""
+    selected: "",
+    imageRenderingMode: "always-original" // or always-template
   }}
 />;
 ```

--- a/ios/RNAirView.swift
+++ b/ios/RNAirView.swift
@@ -14,6 +14,7 @@ public class RNAirView:UIView {
         let selected = source["selected"]
         let focused = source["focused"]
         let disabled = source["disabled"]
+        let rawImageRenderingMode = source["imageRenderingMode"]
 
         if let vv = self._volumeView {
             if let normalImage = self.getImage(source: normal) {
@@ -32,6 +33,23 @@ public class RNAirView:UIView {
             }
             if let disabledImage = self.getImage(source: disabled) {
                 vv.setRouteButtonImage(disabledImage, for: .disabled)
+            }
+        }
+        
+        if rawImageRenderingMode == "always-template" {
+            let imageRenderingMode = rawImageRenderingMode == "always-template"
+                ? UIImage.RenderingMode.alwaysTemplate
+                : rawImageRenderingMode == "always-original"
+                ? .alwaysOriginal
+                : .automatic
+            for view in self._volumeView?.subviews ?? [] {
+                if let buttonOnVolumeView = view as? UIButton {
+                    self._volumeView?.setRouteButtonImage(
+                        buttonOnVolumeView.currentImage?.withRenderingMode(imageRenderingMode),
+                        for: .normal
+                    )
+                    break;
+                }
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-native-airplay-ios",
   "description": "AirPlay library for iOS",
   "summary": "Summary for PODS",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "author": {
     "name": "Andrey Efremov"
   },


### PR DESCRIPTION
First of all: thanks for all your work!

In our application, the navigation bar has a light background, though `MPVolumeView` is always white.
This lead to a white control on top of a white background. 😅

This PR adds the `imageRenderingMode`-option. When set to `always-template`, it will use the current `tintColor` of iOS.